### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,6 +1,8 @@
 # This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
 # See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
 name: CMake on multiple platforms
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/RedKat404/QShell/security/code-scanning/1](https://github.com/RedKat404/QShell/security/code-scanning/1)

To fix the problem, add a `permissions` block at the top level of the workflow (immediately below `name`, before `on:`, or at the same indentation as `name` and `on`). The permissions should be as restrictive as possible while not breaking the workflow. For CI build-and-test workflows, `contents: read` is generally sufficient, allowing only the downloading of code, not modification or creation of repo resources. If more granular or broad permissions become necessary in the future, they can be modified accordingly at the job or step level. No other changes are necessary for this fix.

#### Implementation steps:
- Insert a block:
  ```yaml
  permissions:
    contents: read
  ```
- Place it after the `name:` field and before the `on:` field.  

No changes are needed to the jobs, steps, or other parts of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
